### PR TITLE
update santa language-pack.ts ios output path

### DIFF
--- a/src/team/component/santa/language-pack.ts
+++ b/src/team/component/santa/language-pack.ts
@@ -141,11 +141,11 @@ export async function getLanguagePackForIos(
     th += row[5] + "\n";
   }
   return {
-    "Sources/Toeic/SantaResources/Resources/ko.lproj/Localizable.strings": ko,
-    "Sources/Toeic/SantaResources/Resources/ja.lproj/Localizable.strings": ja,
-    "Sources/Toeic/SantaResources/Resources/en.lproj/Localizable.strings": en,
-    "Sources/Toeic/SantaResources/Resources/vi.lproj/Localizable.strings": vi,
-    "Sources/Toeic/SantaResources/Resources/zh-Hant-TW.lproj/Localizable.strings": zhHant,
-    "Sources/Toeic/SantaResources/Resources/th.lproj/Localizable.strings": th,
+    "Sources/Toeic/SantaResources/Localizables/ko.lproj/Localizable.strings": ko,
+    "Sources/Toeic/SantaResources/Localizables/ja.lproj/Localizable.strings": ja,
+    "Sources/Toeic/SantaResources/Localizables/en.lproj/Localizable.strings": en,
+    "Sources/Toeic/SantaResources/Localizables/vi.lproj/Localizable.strings": vi,
+    "Sources/Toeic/SantaResources/Localizables/zh-Hant-TW.lproj/Localizable.strings": zhHant,
+    "Sources/Toeic/SantaResources/Localizables/th.lproj/Localizable.strings": th,
   };
 }


### PR DESCRIPTION
santa ios language pack path가 변경되어 요청드립니다.

혹시 language pack path를 parameter로 입력받아서 쓸 수 는 없을까요? 매번 저희가 번거롭게 하는것 같아서요

ex) 
deno run -A --unstable https://deno.land/x/riiidx@v0.0.9/team/component/santa/language-pack.ts ios Sources/Toeic/SantaResources/Localizables/