### PR TITLE
app-store-metadata.ts의 cliffy 버전 수정

### DIFF
--- a/src/team/component/santa/app-store-metadata.ts
+++ b/src/team/component/santa/app-store-metadata.ts
@@ -1,4 +1,4 @@
-import { Select } from "https://deno.land/x/cliffy@v0.24.3/prompt/mod.ts";
+import { Select } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
 import { signIn } from "../../../3rd-party/google/auth.ts";
 import * as fs from "https://deno.land/std@0.150.0/fs/mod.ts";
 import { dirname } from "https://deno.land/std@0.150.0/path/mod.ts";


### PR DESCRIPTION
metadata 업데이트가 실패해서 app-store-metadata.ts의 cliffy 버전을 업데이트했습니다.