### PR TITLE
feat: spec-fetcher 릴리스 병렬 다운로드

### DIFF
--- a/src/team/component/santa/spec-fetcher/src/fetcher.ts
+++ b/src/team/component/santa/spec-fetcher/src/fetcher.ts
@@ -22,6 +22,7 @@ interface SpecFileContent {
 }
 
 const DEFAULT_FILENAME_PATTERN = "spec.json" as const;
+const DOWNLOAD_CONCURRENCY = 5 as const;
 
 const fetcher = async (opts: FetcherOptions) => {
   try {
@@ -44,43 +45,38 @@ const fetcher = async (opts: FetcherOptions) => {
     };
   });
 
-  async function* getReleaseItems() {
-    for (const { releaseTitle, repository, filenamePattern } of specs) {
-      const specOutputDir = `${opts.output}/${repository}`;
-      const specName = `${repository}@${releaseTitle}`;
+  const downloadSpec = async (
+    { releaseTitle, repository, filenamePattern }: Spec,
+  ) => {
+    const specOutputDir = `${opts.output}/${repository}`;
+    const specName = `${repository}@${releaseTitle}`;
 
-      console.log(`📥 Downloading ${specName}...`);
-      try {
-        const output = await new Deno.Command(
-          "gh",
-          {
-            args: [
-              "release",
-              "download",
-              releaseTitle,
-              `--repo`,
-              repository,
-              `--pattern`,
-              filenamePattern,
-              `--dir`,
-              specOutputDir,
-            ],
-          },
-        ).output();
-        if (!output.success) {
-          const errorMessage = new TextDecoder().decode(output.stderr);
-          throw new Error(
-            `spec-fetcher: 🚨 Failed to download ${specName}.\nPlease check below original error message.\n\n${errorMessage}`,
-          );
-        }
-        await fs.access(specOutputDir);
-        yield true;
-      } catch (e) {
-        console.error(e);
-        Deno.exit(1);
-      }
+    console.log(`📥 Downloading ${specName}...`);
+    const output = await new Deno.Command(
+      "gh",
+      {
+        args: [
+          "release",
+          "download",
+          releaseTitle,
+          `--repo`,
+          repository,
+          `--pattern`,
+          filenamePattern,
+          `--dir`,
+          specOutputDir,
+        ],
+      },
+    ).output();
+    if (!output.success) {
+      const errorMessage = new TextDecoder().decode(output.stderr);
+      throw new Error(
+        `spec-fetcher: 🚨 Failed to download ${specName}.\nPlease check below original error message.\n\n${errorMessage}`,
+      );
     }
-  }
+    await fs.access(specOutputDir);
+  };
+
   try {
     await fs.access(opts.output);
     await fs.rmdir(opts.output, { recursive: true });
@@ -88,8 +84,14 @@ const fetcher = async (opts: FetcherOptions) => {
     // noop
   }
 
-  for await (const _ of getReleaseItems()) {
-    // noop
+  try {
+    for (let i = 0; i < specs.length; i += DOWNLOAD_CONCURRENCY) {
+      const chunk = specs.slice(i, i + DOWNLOAD_CONCURRENCY);
+      await Promise.all(chunk.map((spec) => downloadSpec(spec)));
+    }
+  } catch (e) {
+    console.error(e);
+    Deno.exit(1);
   }
   console.log(`👍 All spec files were downloaded to the path '${opts.output}'`);
 };


### PR DESCRIPTION
## 변경 사항

`spec-fetcher`의 `gh release download`를 **순차 → 병렬(청크 5개)** 로 변경했습니다.

### 기존
async generator로 `for await` 루프를 돌며 spec을 하나씩 다운로드 — 앞 다운로드가 끝나야 다음이 시작됨.

### 변경
- 다운로드 로직을 `downloadSpec(spec)` 함수로 분리
- spec들을 `DOWNLOAD_CONCURRENCY = 5` 단위로 끊어, 각 청크를 `Promise.all`로 동시 다운로드
- 동시 실행 `gh` 프로세스를 최대 5개로 제한해 시스템 부하를 억제

### 동작 유지
- 출력 디렉토리 사전 삭제 후 다운로드하는 순서 그대로
- 실패 시 원본 에러 메시지 출력 후 `Deno.exit(1)`

### 참고
병렬 특성상 한 청크 내에서 하나가 실패해도 같은 청크의 다른 다운로드는 진행되던 중이라 중간 산출물이 남을 수 있습니다.

## 검증
- `deno check` 통과