### PR TITLE
feat: spec 파일에 concurrent 필드 추가

### DIFF
--- a/src/team/component/santa/spec-fetcher/README.md
+++ b/src/team/component/santa/spec-fetcher/README.md
@@ -62,6 +62,7 @@ Options:
 파일을 참고해주세요.
 
 ```yaml
+concurrent: 동시에 다운로드할 spec의 최대 개수, 1 이상의 정수 # (optional) (default: 1)
 specs:
   # 아래 형식으로 복수의 spec item을 명시할 수 있습니다.
   - repository: 'username/repository' 형식의 string

--- a/src/team/component/santa/spec-fetcher/sample-spec.yml
+++ b/src/team/component/santa/spec-fetcher/sample-spec.yml
@@ -1,3 +1,4 @@
+concurrent: 5
 specs:
   - repository: riiid/abcd-interface
     release-title: v1.2.3

--- a/src/team/component/santa/spec-fetcher/src/fetcher.ts
+++ b/src/team/component/santa/spec-fetcher/src/fetcher.ts
@@ -14,6 +14,7 @@ interface Spec {
 }
 
 interface SpecFileContent {
+  concurrent?: number;
   specs: {
     repository: string;
     "release-title": string;
@@ -22,7 +23,7 @@ interface SpecFileContent {
 }
 
 const DEFAULT_FILENAME_PATTERN = "spec.json" as const;
-const DOWNLOAD_CONCURRENCY = 5 as const;
+const DEFAULT_CONCURRENT = 1 as const;
 
 const fetcher = async (opts: FetcherOptions) => {
   try {
@@ -36,6 +37,8 @@ const fetcher = async (opts: FetcherOptions) => {
   const data = await fs.readFile(opts.input, { encoding: "utf8" });
   const parsed = parseYaml(data) as SpecFileContent;
   await validator.input(parsed);
+
+  const concurrent = parsed.concurrent ?? DEFAULT_CONCURRENT;
 
   const specs: Array<Spec> = parsed.specs.map((item) => {
     return {
@@ -85,8 +88,8 @@ const fetcher = async (opts: FetcherOptions) => {
   }
 
   try {
-    for (let i = 0; i < specs.length; i += DOWNLOAD_CONCURRENCY) {
-      const chunk = specs.slice(i, i + DOWNLOAD_CONCURRENCY);
+    for (let i = 0; i < specs.length; i += concurrent) {
+      const chunk = specs.slice(i, i + concurrent);
       await Promise.all(chunk.map((spec) => downloadSpec(spec)));
     }
   } catch (e) {

--- a/src/team/component/santa/spec-fetcher/src/validator/input.ts
+++ b/src/team/component/santa/spec-fetcher/src/validator/input.ts
@@ -11,6 +11,15 @@ const validateLockFile = (data: Record<string, any>): true | string => {
   if (specs.length === 0) {
     return `No item exists to fetch.`;
   }
+  const concurrent = data?.["concurrent"];
+  if (
+    concurrent !== undefined &&
+    (typeof concurrent !== "number" ||
+      !Number.isInteger(concurrent) ||
+      concurrent < 1)
+  ) {
+    return `A key 'concurrent' must be a positive integer.`;
+  }
   if (
     specs.some((item) => {
       const repository = item?.["repository"];


### PR DESCRIPTION
## 변경 사항

spec 파일 최상위에 optional `concurrent` 필드를 추가하여 다운로드 동시 실행 개수(threshold)를 사용자가 제어할 수 있게 했습니다.

- 기존: 하드코딩된 상수(`DOWNLOAD_CONCURRENCY = 5`)로 청크 크기 고정
- 변경: spec 파일의 `concurrent` 값을 청크 크기로 사용
- **optional 필드이며 기본값은 1** (미지정 시 순차 다운로드)

### validator
`concurrent`가 존재하면 **1 이상의 정수**인지 검증합니다.

```yaml
concurrent: 5   # optional, default 1
specs:
  - repository: riiid/abcd-interface
    release-title: v1.2.3
```

### 문서
- `README.md`, `sample-spec.yml`에 `concurrent` 필드 사용법 추가

## 검증
- `deno check` 통과